### PR TITLE
Pushing to BitBucket without all the force

### DIFF
--- a/lib/github_bitbucket_deployer/git.rb
+++ b/lib/github_bitbucket_deployer/git.rb
@@ -5,7 +5,7 @@ require 'github_bitbucket_deployer/clone_logger_fix'
 
 module GithubBitbucketDeployer
   class Git
-    attr_reader :bitbucket_repo_url, :git_repo_name, :id_rsa, :repo_dir, :logger
+    attr_reader :bitbucket_repo_url, :git_repo_name, :id_rsa, :repo_dir, :logger, :force
 
     def initialize(options)
       @bitbucket_repo_url = options[:bitbucket_repo_url]
@@ -13,6 +13,7 @@ module GithubBitbucketDeployer
       @id_rsa = options[:id_rsa]
       @logger = options[:logger]
       @repo_dir = options[:repo_dir]
+      @force = options[:force].nil? ? true : options[:force]
     end
 
     def push_app_to_bitbucket(remote = 'bitbucket', branch = 'master')
@@ -49,7 +50,7 @@ module GithubBitbucketDeployer
     def push(remote, branch)
       logger.info("git push: deploying #{repo.dir} to " \
                   "#{repo.remote(remote).url} from branch #{branch}")
-      run { repo.push(remote, branch, force: true) }
+      run { repo.push(remote, branch, force: force) }
     end
 
     def add_remote(remote = 'bitbucket')

--- a/lib/github_bitbucket_deployer/git.rb
+++ b/lib/github_bitbucket_deployer/git.rb
@@ -13,7 +13,7 @@ module GithubBitbucketDeployer
       @id_rsa = options[:id_rsa]
       @logger = options[:logger]
       @repo_dir = options[:repo_dir]
-      @force = options[:force].nil? ? true : options[:force]
+      @force = options.fetch(:force, true)
     end
 
     def push_app_to_bitbucket(remote = 'bitbucket', branch = 'master')

--- a/lib/github_bitbucket_deployer/version.rb
+++ b/lib/github_bitbucket_deployer/version.rb
@@ -1,3 +1,3 @@
 module GithubBitbucketDeployer
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/lib/github_bitbucket_deployer/git_spec.rb
+++ b/spec/lib/github_bitbucket_deployer/git_spec.rb
@@ -4,6 +4,7 @@ describe GithubBitbucketDeployer::Git do
   include GitHelpers
 
   let(:git) { described_class.new(options) }
+  let(:gentle_git) { described_class.new(gentle_options) }
 
   let(:options) do
     { bitbucket_repo_url: bitbucket_repo_url,
@@ -12,6 +13,8 @@ describe GithubBitbucketDeployer::Git do
       logger: logger,
       repo_dir: repo_dir }
   end
+
+  let(:gentle_options) { options.merge(force: false) }
 
   let(:bitbucket_repo_url) { 'git@bitbucket.org:g5dev/some_repo.git' }
   let(:git_repo_name) { 'some_repo' }
@@ -71,6 +74,14 @@ describe GithubBitbucketDeployer::Git do
     it 'sets the repo_dir' do
       expect(git.repo_dir).to eq(repo_dir)
     end
+
+    it 'defaults to a forced push' do
+      expect(git.force).to be true
+    end
+
+    it 'can also be gentle' do
+      expect(gentle_git.force).to be false
+    end
   end
 
   describe '#push_app_to_bitbucket', :fakefs do
@@ -102,6 +113,12 @@ describe GithubBitbucketDeployer::Git do
           expect(git_repo).to receive(:push)
             .with('bitbucket', 'master', force: true)
           push_app
+        end
+
+        it 'can also be gentle' do
+          expect(git_repo).to receive(:push)
+            .with('bitbucket', 'master', force: false)
+          gentle_git.push_app_to_bitbucket
         end
       end
 


### PR DESCRIPTION
Now that the Blog service is deploying sitemap data to CLW's, we need the option to NOT `--force` our Git pushes to BitBucket.  If there's some discrepancy in repos, we'd rather have the blog service not mess with anything and just retry its deploy later.  

This is important when someone is mashing "Publish" buttons in a CMS, or the deploy queue in The Provisioner is all backed up. Those scenarios can lead to both the CMS and the Blog service trying to deploy at about the same time. Now when that happens, CMS deploys will essentially get priority since they happen with a forced push. 

https://www.pivotaltracker.com/story/show/131896189